### PR TITLE
Split loadcode into chunks automatically

### DIFF
--- a/src/context.tsx
+++ b/src/context.tsx
@@ -8,7 +8,23 @@ import {
 } from 'react';
 import { useSettingsContext } from './settingsContext';
 import { Class } from './main/load';
-import { splitIntoChunks } from './main/util'
+
+/**
+ * 
+ * @param loadCode The raw TEVE load code saved in wc3 documents.
+ * @param chunkSize The max size of an ingame chat message in wc3.
+ * @returns An array of strings, each containing a chunk of the load code. Handles load codes no matter the length.
+ */
+function splitIntoChunks(loadCode: string): string[] {
+  const result: string[] = [];
+  const chunkSize = 120;
+    
+  for (let i = 0; i < loadCode.length; i += chunkSize) {
+      result.push(loadCode.slice(i, i + chunkSize));
+  }
+  
+  return result;
+}
 
 interface CharacterContext {
   allClasses: Class[];

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import { useSettingsContext } from './settingsContext';
 import { Class } from './main/load';
+import { splitIntoChunks } from './main/util'
 
 interface CharacterContext {
   allClasses: Class[];
@@ -40,16 +41,14 @@ export const CharacterProvider: FC<PropsWithChildren> = ({ children }) => {
   };
   const onLoadClick = (character: Class, legacy?: boolean) => {
     if (character && character.code) {
+      const loadCodeChunks = splitIntoChunks(character.code);
+
       window.electron.ipcRenderer.sendMessage(
         'load',
         [
           '-rp',
           '-lc',
-          character.code.slice(0, character.code.length / 2),
-          character.code.slice(
-            character.code.length / 2,
-            character.code.length,
-          ),
+          ...loadCodeChunks,
           '-le',
           ...extraLines.split('\n'),
         ],

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -11,3 +11,20 @@ export function resolveHtmlPath(htmlFileName: string) {
   }
   return `file://${path.resolve(__dirname, '../renderer/', htmlFileName)}`;
 }
+
+/**
+ * 
+ * @param loadCode The raw TEVE load code saved in wc3 documents.
+ * @param chunkSize The max size of an ingame chat message in wc3.
+ * @returns An array of strings, each containing a chunk of the load code. Each chunk 
+ */
+export function splitIntoChunks(loadCode: string): string[] {
+  const result: string[] = [];
+  const chunkSize = 120;
+    
+  for (let i = 0; i < loadCode.length; i += chunkSize) {
+      result.push(loadCode.slice(i, i + chunkSize));
+  }
+  
+  return result;
+}

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -11,20 +11,3 @@ export function resolveHtmlPath(htmlFileName: string) {
   }
   return `file://${path.resolve(__dirname, '../renderer/', htmlFileName)}`;
 }
-
-/**
- * 
- * @param loadCode The raw TEVE load code saved in wc3 documents.
- * @param chunkSize The max size of an ingame chat message in wc3.
- * @returns An array of strings, each containing a chunk of the load code. Each chunk 
- */
-export function splitIntoChunks(loadCode: string): string[] {
-  const result: string[] = [];
-  const chunkSize = 120;
-    
-  for (let i = 0; i < loadCode.length; i += chunkSize) {
-      result.push(loadCode.slice(i, i + chunkSize));
-  }
-  
-  return result;
-}


### PR DESCRIPTION
This change makes the load code functionality handle codes longer than 2 messages automatically

To be able to test this I had to fix some things related to webpack and then build it to production, I was not able to build it for "dev". I did not include those changes in this pr, because it would be a very messy pr in that case.

So please test this before merging to see if it actually works.
