### PR TITLE
Added missing hyrule prophet icons, fixed crafting recipes

### DIFF
--- a/src/constants/items/forging/pieces.ts
+++ b/src/constants/items/forging/pieces.ts
@@ -123,4 +123,14 @@ export const pieces: { [id: string]: EvoItem } = {
     crafting: [],
     source: 'Blacksmith',
   },
+  'Fabled Armor Piece': {
+    id: 'Fabled Armor Piece',
+    restriction: EvoItemRestictions.FORGE,
+    rarity: EvoRarity.MYTHIC,
+    icon: 'ArmorPiece',
+    description: '',
+    effects: [],
+    crafting: [],
+    source: 'Blacksmith',
+  }
 };

--- a/src/constants/items/mythic/hyruleProphet.ts
+++ b/src/constants/items/mythic/hyruleProphet.ts
@@ -5,41 +5,111 @@ import { EvoRarity } from '../../rarity';
 export const hyruleProphetItems: { [id: string]: EvoItem } = {
   'Angelic Hope': {
     id: 'Angelic Hope',
-    restriction: EvoItemRestictions.MELEE,
+    restriction: EvoItemRestictions.FORGING_MATERIAL,
     rarity: EvoRarity.MYTHIC,
     icon: 'AngelicHope',
     description:
-      "The rise of the archangels.",
+      "The rise of the archangels. Requires 16 Mysterious Notes.",
     effects: [],
     crafting:
     [
-      'Angel Creation',
-      'Angel Feather',
-      'Angel Fire',
+      'Fabled Armor Piece',
       'Angelic Heart',
       'Pure Ignited Incinerator',
       'Pure Light Synthesis',
     ],
-    source: 'Cursed Heaven',
+    source: 'Hyrule Prophet',
   },
   'Angelic Heart': {
     id: 'Angelic Heart',
-    restriction: EvoItemRestictions.MELEE,
+    restriction: EvoItemRestictions.FORGING_MATERIAL,
     rarity: EvoRarity.MYTHIC,
     icon: 'AngelicHeart',
     description:
-      "The heart of divine.",
+      "The heart of divine. Requires 12 Mysterious Notes.",
     effects: [],
-    source: 'Cursed Heaven',
+    crafting: [
+      'Angel Creation',
+      'Angel Feather',
+      'Angel Fire',
+      'Harbinger\'s Heart',
+      'Pure Light Synthesis'
+    ],
+    source: 'Hyrule Prophet',
   },
   "Harbinger's Heart": {
     id: "Harbinger's Heart",
-    restriction: EvoItemRestictions.MELEE,
+    restriction: EvoItemRestictions.FORGING_MATERIAL,
     rarity: EvoRarity.MYTHIC,
     icon: 'HarbingersHeart',
     description:
-      "The pure essence of Harbinger, his heart itself.",
+      "The pure essence of Harbinger, his heart itself. Requires 6 Mysterious Notes.",
     effects: [],
-    source: 'Cursed Heaven',
+    crafting: [
+      "Harbinger's Essence",
+      "Harbinger's Essence",
+      "Harbinger's Essence",
+    ],
+    source: 'Hyrule Prophet',
+  },
+  "Disenchant Triforce Relics": {
+    id: "Disenchant Triforce Relics",
+    restriction: EvoItemRestictions.FORGING_MATERIAL,
+    rarity: EvoRarity.MYTHIC,
+    icon: 'DisenchantTriforceRelics',
+    description:
+      "Disenchants your ancient Triforce Relics in your Hero's First Inventory Slot into:",
+    effects: [],
+    crafting: [
+      'Unpurified Triforce Fragment = 3 Cursed Heaven Prestige',
+      'Unpurified Triforce Shard = 6 Cursed Heaven Prestige',
+      'Triforce Shard = 6 Cursed Heaven Prestige + Light Synthesis',
+      'Triforce Piece = 12 Cursed Heaven Prestige + Pure Light Synthesis',
+      'Inspirit = 12 Cursed Heaven Prestige',
+      'Triforce = 36 Cursed Heaven Prestige + 3 Pure Light Synthesis',
+    ],
+    source: 'Hyrule Prophet',
+  },
+  "Pure Light Synthesis": {
+    id: "Pure Light Synthesis",
+    restriction: EvoItemRestictions.FORGING_MATERIAL,
+    rarity: EvoRarity.MYTHIC,
+    icon: 'PureLightSynthesis',
+    description:
+      'A stronger binding material for angelic relics.',
+    effects: [],
+    crafting: [
+      'Light Synthesis',
+      'Light Synthesis',
+    ],
+    source: 'Hyrule Prophet'
+  },
+  "Ignited Incinerator": {
+    id: "Ignited Incinerator",
+    restriction: EvoItemRestictions.FORGING_MATERIAL,
+    rarity: EvoRarity.MYTHIC,
+    icon: 'IgnitedIncinerator',
+    description:
+      "The true incineration. Requires 9 Mysterious Notes.",
+    effects: [],
+    crafting: [
+      'Incinerator',
+      'Nether Reactor',
+    ],
+    source: 'Hyrule Prophet'
+  },
+  "Pure Ignited Incinerator": {
+    id: "Pure Ignited Incinerator",
+    restriction: EvoItemRestictions.FORGING_MATERIAL,
+    rarity: EvoRarity.MYTHIC,
+    icon: 'PureIgnitedIncinerator',
+    description:
+      "The pure incineration. Requires 10 Mysterious Notes.",
+    effects: [],
+    crafting: [
+      'Ignited Incinerator',
+      'Pure Light Synthesis',
+    ],
+    source: 'Hyrule Prophet'
   },
 }

--- a/src/icons/hyruleProphetIcons.ts
+++ b/src/icons/hyruleProphetIcons.ts
@@ -1,9 +1,17 @@
 import AngelicHeart from './png/evo/hyruleProphet/AngelicHeart.png';
 import AngelicHope from './png/evo/hyruleProphet/AngelicHope.png';
 import HarbingersHeart from './png/evo/hyruleProphet/HarbingersHeart.png';
+import DisenchantTriforceRelics from './png/evo/hyruleProphet/BTNDH_Holy_Shields.png'
+import PureLightSynthesis from './png/evo/hyruleProphet/BTNLightStrike.png'
+import IgnitedIncinerator from './png/evo/hyruleProphet/IgnitedIncinerator.png'
+import PureIgnitedIncinerator from './png/evo/hyruleProphet/PureIgnitedIncinerator.png'
 
 export const hyruleProphetIcons = {
   AngelicHeart,
   AngelicHope,
   HarbingersHeart,
+  DisenchantTriforceRelics,
+  PureLightSynthesis,
+  IgnitedIncinerator,
+  PureIgnitedIncinerator,
 }


### PR DESCRIPTION
This pr adds the fabled armor piece, some missing entries from the hyrule prophet and the relevant icons so they get rendered in evo helper.

It also changes some of the existing hyrule prophet crafting recipes to match the current version of the game.