### PR TITLE
allow any key to be binded to fishing rod

### DIFF
--- a/src/renderer/pages/FishingPage.tsx
+++ b/src/renderer/pages/FishingPage.tsx
@@ -22,7 +22,7 @@ export function FishingPage() {
     window.electron.ipcRenderer.sendMessage('fishing_disarm');
   }
 
-  const keys = Object.keys(Key).filter((item) => !isNaN(Number(item))).map(item => Number(item));
+  const keys = Object.keys(Key).map(item => Number(item)).filter((item) => !isNaN(item));
 
   return (
     <>

--- a/src/renderer/pages/FishingPage.tsx
+++ b/src/renderer/pages/FishingPage.tsx
@@ -22,7 +22,7 @@ export function FishingPage() {
     window.electron.ipcRenderer.sendMessage('fishing_disarm');
   }
 
-  const keys = Object.keys(Key).filter((item) => isNaN(Number(item)));
+  const keys = Object.keys(Key).filter((item) => !isNaN(Number(item))).map(item => Number(item));
 
   return (
     <>
@@ -43,8 +43,8 @@ export function FishingPage() {
           label="Age"
         >
           {keys.map(value => (
-            <MenuItem key={value} value={Key[value]}>
-              {value}
+            <MenuItem value={value}>
+              {Key[value]}
             </MenuItem>
           ))}
         </Select>

--- a/src/renderer/pages/FishingPage.tsx
+++ b/src/renderer/pages/FishingPage.tsx
@@ -22,6 +22,8 @@ export function FishingPage() {
     window.electron.ipcRenderer.sendMessage('fishing_disarm');
   }
 
+  const keys = Object.keys(Key).filter((item) => isNaN(Number(item)));
+
   return (
     <>
       <Typography variant="h6">Current hotkeys:</Typography>
@@ -40,13 +42,11 @@ export function FishingPage() {
           onChange={handleChange}
           label="Age"
         >
-          <MenuItem value={Key.NumPad8}>Numpad 8</MenuItem>
-          <MenuItem value={Key.Num6}>6</MenuItem>
-          <MenuItem value={Key.Num5}>5</MenuItem>
-          <MenuItem value={Key.Num4}>4</MenuItem>
-          <MenuItem value={Key.Num3}>3</MenuItem>
-          <MenuItem value={Key.Num2}>2</MenuItem>
-          <MenuItem value={Key.Num1}>1</MenuItem>
+          {keys.map(value => (
+            <MenuItem key={value} value={Key[value]}>
+              {value}
+            </MenuItem>
+          ))}
         </Select>
       </FormControl>
       <br />


### PR DESCRIPTION
this is helpful for people who do not use default bindings for items

![image](https://github.com/ArgentumHeart/EvoHelper/assets/13066380/db461b28-75cd-48cd-b882-15179df487db)
