### PR TITLE
rework fishing

### DIFF
--- a/src/main/fishing.ts
+++ b/src/main/fishing.ts
@@ -32,9 +32,7 @@ export function armFishing(rodHotkey: any) {
       }
     })
   });
-  globalShortcut.register(getCommandFor('-'), () => {
-    stop();
-  });
+  globalShortcut.register(getCommandFor('-'), () => stop());
 }
 
 export function disarmFishing() {

--- a/src/renderer/pages/FishingPage.tsx
+++ b/src/renderer/pages/FishingPage.tsx
@@ -25,8 +25,9 @@ export function FishingPage() {
   return (
     <>
       <Typography variant="h6">Current hotkeys:</Typography>
-      <Typography variant="body2">Ctrl + 9: fish perfect</Typography>
-      <Typography variant="body2">Ctrl + 0: fish standard</Typography>
+      <Typography variant="body2">Ctrl + 8: almost perfect fishing (~9500 score)</Typography>
+      <Typography variant="body2">Ctrl + 9: perfect fishing</Typography>
+      <Typography variant="body2">Ctrl + 0: standard fishing</Typography>
       <Typography variant="body2">Ctrl + -: pause</Typography>
 
       <Typography variant="body1">Set 1920x1080 resolution for this to work.</Typography>


### PR DESCRIPTION
- add new fishing - almost perfect - should have perfect score in 19/20 cases, miss or have bad score in 1/20 cases. This was requested for endgame fishing so that fish that can kill player doesn't spawn.
- reduce duplication by extracting common methods
- refactor code to use async await instead of then
- use await promise instead of settimeout to be able to change delay dynamically for almost perfect fishing
- reorganize file based on uncle bob's suggestion: public methods first, private methods are defined in order of usage